### PR TITLE
add .sln and csproj with dynamo package output on build

### DIFF
--- a/dynamo-future-file-extension/dynamo-future-file-extension.sln
+++ b/dynamo-future-file-extension/dynamo-future-file-extension.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32112.339
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FutureFileExtension", "extension\FutureFileExtension.csproj", "{A43F1FD3-73F2-481A-A65A-B2ED3A78DF88}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A43F1FD3-73F2-481A-A65A-B2ED3A78DF88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A43F1FD3-73F2-481A-A65A-B2ED3A78DF88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A43F1FD3-73F2-481A-A65A-B2ED3A78DF88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A43F1FD3-73F2-481A-A65A-B2ED3A78DF88}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DA15821A-ABE4-4E5C-915D-C7107C40698D}
+	EndGlobalSection
+EndGlobal

--- a/dynamo-future-file-extension/extension/Extension.cs
+++ b/dynamo-future-file-extension/extension/Extension.cs
@@ -1,0 +1,128 @@
+﻿using Dynamo.Extensions;
+using Dynamo.Graph.Nodes;
+using Dynamo.Models;
+using HarmonyLib;
+using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Xml;
+using Dynamo.Logging;
+using System.Diagnostics;
+
+namespace Dynamo.FutureFileExtension
+{
+    public class FutureFileExtension : IExtension, ILogSource
+    {
+        private static MethodInfo openxmlmethod;
+        private static MethodInfo openJsonFileMethod;
+
+        public event Action<ILogMessage> MessageLogged;
+
+        public string UniqueId => "277edc98-d327-404e-979c-7c6e6f6956b2";
+
+        public string Name => "FutureFileExtension_File_Compatability";
+
+        public void Dispose()
+        {
+
+        }
+
+        private static string ToEnumString<T>(T type)
+        {
+            var enumType = typeof(T);
+            var name = Enum.GetName(enumType, type);
+            var enumMemberAttribute = ((EnumMemberAttribute[])enumType.GetField(name).GetCustomAttributes(typeof(EnumMemberAttribute), true)).Single();
+            return enumMemberAttribute.Value;
+        }
+
+        public void Ready(ReadyParams sp)
+        {
+            //Debugger.Launch();
+            //if dynamo is newer than 2.11, don't monkey patch anything.
+            if (sp.StartupParams.DynamoVersion > new Version(2, 12, 0))
+            {
+                MessageLogged(LogMessage.Info($"This extension only patches dynamo versions older than 2.12, current version is {Assembly.GetCallingAssembly().GetName().Version}, returning."));
+                return;
+            }
+
+            DoPatching();
+        }
+
+        public void DoPatching()
+        {
+            var harmony = new Harmony("Dynamo.FurureFileExtension.Patch.1");
+
+            var originalOpenFileFromPath = AccessTools.Method(typeof(DynamoModel), nameof(DynamoModel.OpenFileFromPath));
+            var prefix = typeof(FutureFileExtension).GetMethod(nameof(Prefix), System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
+            openxmlmethod = typeof(DynamoModel).GetMethod("OpenXmlFileFromPath", System.Reflection.BindingFlags.NonPublic | BindingFlags.Instance);
+            openJsonFileMethod = typeof(DynamoModel).GetMethod("OpenJsonFileFromPath", System.Reflection.BindingFlags.NonPublic | BindingFlags.Instance);
+            if(originalOpenFileFromPath != null && prefix != null && openxmlmethod != null && openJsonFileMethod != null)
+            {
+                harmony.Patch(originalOpenFileFromPath, new HarmonyMethod(prefix));
+            }
+        }
+        public static bool Prefix(DynamoModel __instance, string filePath, bool forceManualExecutionMode = false)
+        {
+
+            __instance?.Logger?.Log($"openfilepath has been patched from{Assembly.GetExecutingAssembly().FullName }");
+            var knownInputTypeNames = Enum.GetValues(typeof(NodeInputTypes)).Cast<NodeInputTypes>().Select(x => ToEnumString(x));
+            XmlDocument xmlDoc;
+            Exception ex;
+            if (DynamoUtilities.PathHelper.isValidXML(filePath, out xmlDoc, out ex))
+            {
+                openxmlmethod.Invoke(__instance, new object[] { xmlDoc, filePath, forceManualExecutionMode });
+                return false;
+            }
+            else
+            {
+                // These kind of exceptions indicate that file is not accessible 
+                if (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    throw ex;
+                }
+                if (ex is System.Xml.XmlException)
+                {
+                    // XML opening failure can indicate that this file is corrupted XML or Json
+                    string fileContents;
+                    if (DynamoUtilities.PathHelper.isValidJson(filePath, out fileContents, out ex))
+                    {
+                        //at this point filecontents contains a json string - 
+                        //lets parse it, do our transformation and pass it to open method.
+
+                        // TODO we could do more complex replacements, for example, we could replace the WorkspaceConverter.ReadJson method 
+                        // and completely alter how nodeInputs are deserialized. This is just a POC to fix the issue with minimum effort.
+
+                        var root = JObject.Parse(fileContents);
+                        //find all inputs that don't exist in the known types - these are the ones we can't deserialize correctly.
+                        //TODO reason about case sensitivity.
+                        var matchingTokens = root.SelectTokens("Inputs[*].Type").Where(x => !knownInputTypeNames.Contains(x.Value<string>()));
+                        //for now we just replace with "Selection" - but we could avoid deserializing this entire input.
+                        matchingTokens.ToList().ForEach(x => x.Replace(JToken.FromObject("Selection")));
+                        fileContents = root.ToString();
+
+                        openJsonFileMethod.Invoke(__instance, new object[] { fileContents, filePath, forceManualExecutionMode });
+                        return false;
+                    }
+                    else
+                    {
+                        throw ex;
+                    }
+                }
+            }
+            return false;
+        }
+
+        public void Shutdown()
+        {
+
+        }
+
+        public void Startup(StartupParams sp)
+        {
+
+        }
+    }
+}

--- a/dynamo-future-file-extension/extension/FutureFileExtension.csproj
+++ b/dynamo-future-file-extension/extension/FutureFileExtension.csproj
@@ -1,0 +1,134 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A43F1FD3-73F2-481A-A65A-B2ED3A78DF88}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FutureFileExtension</RootNamespace>
+    <AssemblyName>FutureFileExtension</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <OutputPath>extension_output\futurefileextension\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="0Harmony, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Lib.Harmony.2.2.0\lib\net45\0Harmony.dll</HintPath>
+    </Reference>
+    <Reference Include="DesignScriptBuiltin, Version=2.0.4.11375, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.4.11375\lib\net45\DesignScriptBuiltin.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DSIronPython, Version=2.0.4.11375, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.4.11375\lib\net45\DSIronPython.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoApplications, Version=2.0.4.11375, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.4.11375\lib\net45\DynamoApplications.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoCore, Version=2.0.4.11375, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.4.11375\lib\net45\DynamoCore.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoInstallDetective, Version=2.0.4.11375, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.4.11375\lib\net45\DynamoInstallDetective.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoServices, Version=2.0.4.11375, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.DynamoServices.2.0.4.11375\lib\net45\DynamoServices.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoShapeManager, Version=2.0.4.11375, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.4.11375\lib\net45\DynamoShapeManager.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoUnits, Version=2.0.4.11375, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.2.0.4.11375\lib\net45\DynamoUnits.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoUtilities, Version=2.0.4.11375, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.4.11375\lib\net45\DynamoUtilities.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Expression.Interactions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\Microsoft.Expression.Interactions.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Prism, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\Microsoft.Practices.Prism.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Prism.Interactivity, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\Microsoft.Practices.Prism.Interactivity.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="ProtoCore, Version=2.0.4.11375, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.4.11375\lib\net45\ProtoCore.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.2.0.4.11375\lib\net45\ProtoGeometry.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\System.Windows.Interactivity.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="VMDataBridge, Version=2.0.4.11375, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.4.11375\lib\net45\VMDataBridge.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Extension.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="extension_output\futurefileextension\pkg.json" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="extension_output\futurefileextension\extra\futurefileextension_ExtensionDefinition.xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/dynamo-future-file-extension/extension/Properties/AssemblyInfo.cs
+++ b/dynamo-future-file-extension/extension/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("FutureFileExtension")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("FutureFileExtension")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a43f1fd3-73f2-481a-a65a-b2ed3a78df88")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/dynamo-future-file-extension/extension/extension_output/futurefileextension/extra/futurefileextension_ExtensionDefinition.xml
+++ b/dynamo-future-file-extension/extension/extension_output/futurefileextension/extra/futurefileextension_ExtensionDefinition.xml
@@ -1,0 +1,4 @@
+﻿<ExtensionDefinition>
+  <AssemblyPath>..\bin\FutureFileExtension.dll</AssemblyPath>
+  <TypeName>Dynamo.FutureFileExtension.FutureFileExtension</TypeName>
+</ExtensionDefinition>

--- a/dynamo-future-file-extension/extension/extension_output/futurefileextension/pkg.json
+++ b/dynamo-future-file-extension/extension/extension_output/futurefileextension/pkg.json
@@ -1,0 +1,17 @@
+﻿{
+  "file_hash":null,
+  "name":"dynamofuturefile",
+  "version":"0.0.1",
+  "description":"enables files from the future to load legacy dynamo versions",
+  "group":"",
+  "keywords":[],
+  "dependencies":[],
+  "license":"APACHE2.0",
+  "contents":"",
+  "engine_version":"2.0.1",
+  "engine_metadata":"",
+  "engine":"dynamo",
+  "site_url": "",
+  "repository_url": "",
+  "node_libraries": []
+}

--- a/dynamo-future-file-extension/extension/packages.config
+++ b/dynamo-future-file-extension/extension/packages.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CommonServiceLocator" version="1.0" targetFramework="net452" />
+  <package id="DynamoVisualProgramming.Core" version="2.0.4.11375" targetFramework="net452" />
+  <package id="DynamoVisualProgramming.DynamoServices" version="2.0.4.11375" targetFramework="net452" />
+  <package id="DynamoVisualProgramming.ZeroTouchLibrary" version="2.0.4.11375" targetFramework="net452" />
+  <package id="Lib.Harmony" version="2.2.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
+  <package id="NUnit" version="2.6.3" targetFramework="net452" />
+  <package id="Prism" version="4.1.0.0" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
* Adds .sln and csproj for the "future file extension"
* build produces a package in the "extension_output" folder.
* Package contains 2 binaries, the extension lib and the MIT licensed harmonylib.dll that is used to do the patching.
* I've made this repo APACHE 2.0 licensed to match Dynamo.
* This build references 2.0.4 dynamo nugets, and targets .net4.5.2 for best chance at compatibility between versions.
* Patching will only occur if the Dynamo version is < 2.12.

This PR addresses one aspect of the deserialization failure related to `Inputs` - two other prs will be to Dynamo repo.

After this PR is merged we can publish this package to package manager.

![Screen Shot 2022-03-01 at 4 54 46 PM](https://user-images.githubusercontent.com/508936/156256017-03911c00-c218-4cee-8e78-bf1999d01958.png)

